### PR TITLE
fix: improve rendering of binary and json fields

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -140,31 +140,21 @@ function getMaxRows(): number {
   return maxRows ?? fallbackMaxRows;
 }
 
-function escapeNewline(a: string | number | null): string | number | null {
-  if (typeof a === 'string') {
-    return a.replace(/\n/g, '\\n').replace(/\r/g, '\\r');
-  }
-  return a;
-}
-
-// attempt to serialize all remaining "object" values as JSON
-function serializeNestedObjects(a: any): any {
+function serializeCell(a: any): any {
   try {
-    if (typeof a === 'object') {
-      return JSON.stringify(a);
-    }
-  } finally {
-    return a;
-  }
-}
-
-// serialize buffers as hex strings
-function serializeBinaryAsHex(a: any): any {
-  try {
+    // serialize buffers as hex strings
     if (Buffer.isBuffer(a)) {
       return `0x${a.toString('hex')}`;
     }
-  } finally {
+    // attempt to serialize all remaining "object" values as JSON
+    if (typeof a === 'object') {
+      return JSON.stringify(a);
+    }
+    if (typeof a === 'string') {
+      return a.replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+    }
+    return a;
+  } catch {
     return a;
   }
 }
@@ -172,9 +162,7 @@ function serializeBinaryAsHex(a: any): any {
 function markdownRow(row: Row): string {
   const middle = Object.entries(row)
     .map((pair) => pair[1])
-    .map(serializeBinaryAsHex)
-    .map(serializeNestedObjects)
-    .map(escapeNewline)
+    .map(serializeCell)
     .join(' | ');
   return `| ${middle} |`;
 }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -147,9 +147,33 @@ function escapeNewline(a: string | number | null): string | number | null {
   return a;
 }
 
+// attempt to serialize all remaining "object" values as JSON
+function serializeNestedObjects(a: any): any {
+  try {
+    if (typeof a === 'object') {
+      return JSON.stringify(a);
+    }
+  } finally {
+    return a;
+  }
+}
+
+// serialize buffers as hex strings
+function serializeBinaryAsHex(a: any): any {
+  try {
+    if (Buffer.isBuffer(a)) {
+      return `0x${a.toString('hex')}`;
+    }
+  } finally {
+    return a;
+  }
+}
+
 function markdownRow(row: Row): string {
   const middle = Object.entries(row)
     .map((pair) => pair[1])
+    .map(serializeBinaryAsHex)
+    .map(serializeNestedObjects)
     .map(escapeNewline)
     .join(' | ');
   return `| ${middle} |`;

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -19,7 +19,7 @@ export type ExecutionResult = TabularResult[];
 export type TabularResult = Row[];
 
 // Row represents an arbitrary map of data with marshallable values.
-export type Row = { [key: string]: string | number | null };
+export type Row = { [key: string]: any };
 
 // Conn is an abstraction over driver-specific connection interfaces.
 interface Conn {


### PR DESCRIPTION
Closes #41 and #40 

New behavior:

<img width="777" alt="Screen Shot 2022-04-08 at 12 41 44 PM" src="https://user-images.githubusercontent.com/7585078/162493988-adb1d149-da54-45bc-9dfc-ae1ec4a5aebf.png">

